### PR TITLE
[BUGFIX] Configure autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,5 +9,10 @@
   "version": "7.0.2",
   "require": {
     "typo3/cms-core": ">=6.2.1,<8.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "SpoonerWeb\\BeSecurePw\\": "Classes"
+    }
   }
 }


### PR DESCRIPTION
* To allow TYPO3 to locate classes via composer autoloading
* Necessary if extension is installed via composer as a composer.json
  exists