### PR TITLE
Display of TYPO3-core icons in 6.2 AND 7.6 correctly

### DIFF
--- a/Resources/Public/JavaScript/passwordtester.js
+++ b/Resources/Public/JavaScript/passwordtester.js
@@ -79,7 +79,7 @@ PasswordTester = Class.create({
 				this.passwordField,
 				{
 					tag: 'img',
-					src: '../../../../typo3/sysext/t3skin/icons/gfx/ok.png',
+					src: '../../../../typo3/sysext/t3skin/images/icons/status/dialog-ok.png',
 					id: 'password_strength',
 					style: 'margin: 2px 0 0 5px;'
 				},
@@ -93,7 +93,7 @@ PasswordTester = Class.create({
 				this.passwordField,
 				{
 					tag: 'img',
-					src: '../../../../typo3/sysext/t3skin/icons/gfx/required_h.gif',
+					src: '../../../../typo3/sysext/t3skin/images/icons/status/dialog-warning.png',
 					id: 'password_strength',
 					style: 'margin: 2px 0 0 5px;'
 				},

--- a/Resources/Public/JavaScript/passwordtester.js
+++ b/Resources/Public/JavaScript/passwordtester.js
@@ -79,7 +79,7 @@ PasswordTester = Class.create({
 				this.passwordField,
 				{
 					tag: 'img',
-					src: '../../../../typo3conf/ext/be_secure_pw/Resources/Public/Images/accept.png',
+					src: '../../../../typo3/sysext/t3skin/icons/gfx/ok.png',
 					id: 'password_strength',
 					style: 'margin: 2px 0 0 5px;'
 				},


### PR DESCRIPTION
Switch to t3skin icons which are available in 6.2 AND 7.6