### PR TITLE
[FEATURE] Intuitive form and "save" button

### DIFF
--- a/Classes/Hook/RestrictModulesHook.php
+++ b/Classes/Hook/RestrictModulesHook.php
@@ -61,6 +61,20 @@ class RestrictModulesHook implements \TYPO3\CMS\Core\SingletonInterface
             // allow access to live and workspace, if the user is currently in a workspace,
             // but the access is removed due to missing usergroup
             $GLOBALS['BE_USER']->user['workspace_perms'] = 3;
+            // Disable all columns except password
+            $GLOBALS['TYPO3_USER_SETTINGS']['columns'] = array(
+                'passwordCurrent' => $GLOBALS['TYPO3_USER_SETTINGS']['columns']['passwordCurrent'],
+                'password' => $GLOBALS['TYPO3_USER_SETTINGS']['columns']['password'],
+                'password2' => $GLOBALS['TYPO3_USER_SETTINGS']['columns']['password2'],
+                'savebutton' => array(
+                    'buttonlabel' => 'LLL:EXT:be_secure_pw/Resources/Private/Language/ux_locallang_csh_mod.xml:option_newPassword.savebutton.label',
+                    'label' => '',
+                    'type' => 'button',
+                    'onClick' => 'submit();',
+                ),
+            );
+            // Override showitem to remove tabs and all fields except password
+            $GLOBALS['TYPO3_USER_SETTINGS']['showitem'] = '--div--;LLL:EXT:be_secure_pw/Resources/Private/Language/ux_locallang_csh_mod.xml:option_newPassword.description,passwordCurrent,password,password2,savebutton';
         }
     }
 }

--- a/Resources/Private/Language/ux_locallang_csh_mod.xml
+++ b/Resources/Private/Language/ux_locallang_csh_mod.xml
@@ -8,9 +8,11 @@
 	<data type="array">
 		<languageKey index="default" type="array">
             <label index="option_newPassword.description">Enter a new and secure password for your backend account:</label>
+            <label index="option_newPassword.savebutton.label">Update password</label>
 		</languageKey>
         <languageKey index="de" type="array">
             <label index="option_newPassword.description">Geben Sie ein neues und sicheres Passwort für Ihren Backend Zugang ein:</label>
+            <label index="option_newPassword.savebutton.label">Passwort setzen</label>
         </languageKey>
 	</data>
 </T3locallang>


### PR DESCRIPTION
This makes the form much more intuitive:
- it removes all TCA fields and divs/tabs except the password fields
- it adds a submit button below (our customers legitimately requested this usability feature)

Tested on TYPO3 8 (and its cherry-pick source was tested on 6.2)