### PR TITLE
Remove useless parameters

### DIFF
--- a/Configuration/TCA/Overrides/be_users.php
+++ b/Configuration/TCA/Overrides/be_users.php
@@ -27,4 +27,4 @@ $tempColumns = [
 ];
 
 ExtensionManagementUtility::addTCAcolumns('be_users', $tempColumns);
-ExtensionManagementUtility::addToAllTCAtypes('be_users', 'tx_besecurepw_lastpwchange;;;;1-1-1');
+ExtensionManagementUtility::addToAllTCAtypes('be_users', 'tx_besecurepw_lastpwchange');


### PR DESCRIPTION
Hello Thomas,

Can you look at my change in order to confirm if my modification is good.

Remove useless _parameters.

With these parameters i have some depreciations on TYPO3 7.6.26 : 

Automatic TCA migration done during bootstrap. Please adapt TCA accordingly, these migrations will be removed with TYPO3 CMS 8. The backend module "Configuration -> TCA" shows the modified values. Please adapt these areas :
Changed showitem string of TCA table "be_users" type "0" due to changed field "tx_besecurepw_lastpwchange".
Changed showitem string of TCA table "be_users" type "1" due to changed field "tx_besecurepw_lastpwchange".

Without these parameters, no deprecation log for this.