### PR TITLE
Exclude directories from git export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Folders
+.Build/ export-ignore
+Tests/ export-ignore


### PR DESCRIPTION
For security purpose it is better to exclude developement directories and files from git export.