### PR TITLE
[BUGFIX] Improve compatibility with TYPO3 CMS 10

### DIFF
--- a/Classes/Hook/UserSetupHook.php
+++ b/Classes/Hook/UserSetupHook.php
@@ -15,12 +15,11 @@ namespace SpoonerWeb\BeSecurePw\Hook;
  */
 
 use SpoonerWeb\BeSecurePw\Utilities\PasswordExpirationUtility;
+use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Messaging;
-use TYPO3\CMS\Core\Utility;
 use TYPO3\CMS\Setup\Controller\SetupModuleController;
 use SpoonerWeb\BeSecurePw\Evaluation\PasswordEvaluator;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Backend\Template\DocumentTemplate;
 
 /**
  * Class UserSetupHook
@@ -59,7 +58,7 @@ class UserSetupHook
             $params['be_user_data']['password2'] = '';
             $this->getLanguageLabels();
             /** @var \TYPO3\CMS\Core\Messaging\FlashMessageQueue $messageQueue */
-            $messageQueue = Utility\GeneralUtility::makeInstance(
+            $messageQueue = GeneralUtility::makeInstance(
                 Messaging\FlashMessageQueue::class,
                 'core.template.flashMessages'
             );
@@ -87,7 +86,7 @@ class UserSetupHook
     {
         // get the languages from ext
         if (empty($GLOBALS['LANG'])) {
-            $GLOBALS['LANG'] = Utility\GeneralUtility::makeInstance('language');
+            $GLOBALS['LANG'] = GeneralUtility::makeInstance(LanguageService::class);
             $GLOBALS['LANG']->init($GLOBALS['BE_USER']->uc['lang']);
         }
         $GLOBALS['LANG']->includeLLFile('EXT:be_secure_pw/Resources/Private/Language/locallang.xml');

--- a/Configuration/TCA/Overrides/be_users.php
+++ b/Configuration/TCA/Overrides/be_users.php
@@ -30,3 +30,9 @@ $tempColumns = [
 
 ExtensionManagementUtility::addTCAcolumns('be_users', $tempColumns);
 ExtensionManagementUtility::addToAllTCAtypes('be_users', 'tx_besecurepw_lastpwchange');
+
+$GLOBALS['TCA']['be_users']['columns']['password']['config']['eval'] = implode(',', [
+    'required',
+    \SpoonerWeb\BeSecurePw\Evaluation\PasswordEvaluator::class,
+    'password'
+]);

--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,9 @@
   },
   "require": {
     "php": "^7.2",
-    "typo3/cms-core": "^9.5 || ^10.0",
-    "typo3/cms-setup": "^9.5 || ^10.0",
-    "typo3/cms-beuser": "^9.5 || ^10.0"
+    "typo3/cms-core": "^10.4",
+    "typo3/cms-setup": "^10.4",
+    "typo3/cms-beuser": "^10.4"
   },
   "autoload": {
     "psr-4": {

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -2,18 +2,6 @@
 defined('TYPO3_MODE') || die('Access denied.');
 
 $boot = function () {
-    // for editing per "user settings"
-    $saltedPasswordEvaluator = \TYPO3\CMS\Saltedpasswords\Evaluation\BackendEvaluator::class;
-
-    // set password evaluation for password field in be_users
-    $evaluation = [
-        'required',
-        \SpoonerWeb\BeSecurePw\Evaluation\PasswordEvaluator::class,
-        $saltedPasswordEvaluator,
-        'password'
-    ];
-    $GLOBALS['TCA']['be_users']['columns']['password']['config']['eval'] = implode(',', $evaluation);
-
     /* override language file */
     $GLOBALS['TCA_DESCR']['_MOD_user_setup']['refs'][] =
         'EXT:be_secure_pw/Resources/Private/Language/ux_locallang_csh_mod.xml';


### PR DESCRIPTION
* move TCA changes into `Configuration/TCA/Overrides`
* remove usage `saltedpasswords`
* remove support for TYPO3 CMS 9
* fix instantiation of `LanguageService`